### PR TITLE
improve Rainbow Mode

### DIFF
--- a/minui/graphics.c
+++ b/minui/graphics.c
@@ -161,24 +161,34 @@ void gr_text_blend(int x,int y, GRFont* font)
     text_blend(src_p,font->cwidth,dst_p,gr_draw->row_bytes,font->cwidth,font->cheight);
 }
 
-static unsigned int rainbow_color = 0;
+static int rainbow_index = 0;
 static int rainbow_enabled = 0;
+static int rainbow_colors[] = { 255, 0, 0,        // red
+                                255, 127, 0,      // orange
+                                255, 255, 0,      // yellow
+                                0, 255, 0,        // green
+                                60, 80, 255,      // blue
+                                143, 0, 255 };    // violet
+static int num_rb_colors =
+        (sizeof(rainbow_colors)/sizeof(rainbow_colors[0])) / 3;
 
-static void rainbow() {
-    static int colors[] = { 255, 0, 0,        // red
-                            255, 127, 0,      // orange
-                            255, 255, 0,      // yellow
-                            0, 255, 0,        // green
-                            60, 80, 255,      // blue
-                            143, 0, 255 };    // violet
-
-    gr_color(colors[rainbow_color], colors[rainbow_color+1], colors[rainbow_color+2], 255);
-    rainbow_color += 3;
-    if (rainbow_color >= sizeof(colors)/sizeof(colors[0])) rainbow_color = 0;
+static void rainbow(int col) {
+    int rainbow_color = ((rainbow_index + col) % num_rb_colors) * 3;
+    gr_color(rainbow_colors[rainbow_color], rainbow_colors[rainbow_color+1],
+                rainbow_colors[rainbow_color+2], 255);
 }
 
 void set_rainbow_mode(int enabled) {
     rainbow_enabled = enabled;
+}
+
+void move_rainbow(int x) {
+    rainbow_index += x;
+    if (rainbow_index < 0) {
+        rainbow_index = num_rb_colors - 1;
+    } else if (rainbow_index >= num_rb_colors) {
+        rainbow_index = 0;
+    }
 }
 
 void gr_text(int x, int y, const char *s, int bold)
@@ -194,7 +204,7 @@ void gr_text(int x, int y, const char *s, int bold)
 
     unsigned char ch;
     while ((ch = *s++)) {
-        if (rainbow_enabled) rainbow();
+        if (rainbow_enabled) rainbow(x / font->cwidth);
 
         if (outside(x, y) || outside(x+font->cwidth-1, y+font->cheight-1)) break;
 

--- a/minui/minui.h
+++ b/minui/minui.h
@@ -129,6 +129,7 @@ void res_free_surface(gr_surface surface);
 void gr_text_blend(int x,int y, GRFont* pfont);
 
 void set_rainbow_mode(int enabled);
+void move_rainbow(int x);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Require 5 consecutive menu "wraps" in the same direction to help
  prevent accidental toggling
- Align colors into stripes (i.e. columns)
  a) less prone to induce dizziness in some people when they change
  b) better resembles a rainbow
- Move the stripes to the right when the selection moves up and
  move the stripes to the left when the selection moves down

Change-Id: I3feae173b22f5703c554ca33e634881749ff54cf
