### PR TITLE
updater: Add LZMA support to blockimg

### DIFF
--- a/minzip/Android.mk
+++ b/minzip/Android.mk
@@ -10,9 +10,11 @@ LOCAL_SRC_FILES := \
 
 LOCAL_C_INCLUDES := \
 	external/zlib \
-	external/safe-iop/include
+	external/safe-iop/include \
+	external/lzma/xz-embedded
 
 LOCAL_STATIC_LIBRARIES := libselinux
+LOCAL_STATIC_LIBRARIES += libxz
 
 LOCAL_MODULE := libminzip
 

--- a/minzip/Zip.h
+++ b/minzip/Zip.h
@@ -158,6 +158,18 @@ bool mzProcessZipEntryContents(const ZipArchive *pArchive,
     void *cookie);
 
 /*
+ * Similar to mzProcessZipEntryContents, but explicitly process the stream
+ * using XZ/LZMA before calling processFunction.
+ *
+ * This is a separate function for use by the updater. LZMA provides huge
+ * size reductions vs deflate, but isn't actually supported by the ZIP format.
+ * We need to process it using as little memory as possible.
+ */
+bool mzProcessZipEntryContentsXZ(const ZipArchive *pArchive,
+    const ZipEntry *pEntry, ProcessZipEntryContentsFunction processFunction,
+    void *cookie);
+
+/*
  * Read an entry into a buffer allocated by the caller.
  */
 bool mzReadZipEntry(const ZipArchive* pArchive, const ZipEntry* pEntry,

--- a/updater/Android.mk
+++ b/updater/Android.mk
@@ -43,7 +43,7 @@ endif
 
 LOCAL_STATIC_LIBRARIES += $(TARGET_RECOVERY_UPDATER_LIBS) $(TARGET_RECOVERY_UPDATER_EXTRA_LIBS)
 LOCAL_STATIC_LIBRARIES += libapplypatch libedify libmtdutils libminzip libz
-LOCAL_STATIC_LIBRARIES += libmincrypt libbz
+LOCAL_STATIC_LIBRARIES += libmincrypt libbz libxz
 LOCAL_STATIC_LIBRARIES += libcutils liblog libstdc++ libc
 LOCAL_STATIC_LIBRARIES += libselinux
 tune2fs_static_libraries := \

--- a/updater/blockimg.c
+++ b/updater/blockimg.c
@@ -241,7 +241,12 @@ static bool receive_new_data(const unsigned char* data, int size, void* cookie) 
 
 static void* unzip_new_data(void* cookie) {
     NewThreadInfo* nti = (NewThreadInfo*) cookie;
-    mzProcessZipEntryContents(nti->za, nti->entry, receive_new_data, nti);
+    if (strncmp(".xz", nti->entry->fileName + (nti->entry->fileNameLen - 3), 3) == 0) {
+        mzProcessZipEntryContentsXZ(nti->za, nti->entry, receive_new_data, nti);
+    } else {
+        mzProcessZipEntryContents(nti->za, nti->entry, receive_new_data, nti);
+    }
+
     return NULL;
 }
 


### PR DESCRIPTION
- This adds support for LZMA compressed blockimages. The space savings
  from doing this is significant and will reduce our CDN costs by quite
  a bit.
- I'll spend the saved $$$ on beer.

Change-Id: I6679220aaa29592fe6bbccd4136f0c239e45e2ae
