### PR TITLE
updater: Hoist fsync() to outer loop.

### DIFF
--- a/updater/blockimg.c
+++ b/updater/blockimg.c
@@ -136,11 +136,6 @@ static int write_all(int fd, const uint8_t* data, size_t size) {
         }
     }
 
-    if (fsync(fd) == -1) {
-        fprintf(stderr, "fsync failed: %s\n", strerror(errno));
-        return -1;
-    }
-
     return 0;
 }
 
@@ -665,7 +660,7 @@ static int WriteStash(const char* base, const char* id, int blocks, uint8_t* buf
 
     fprintf(stderr, " writing %d blocks to %s\n", blocks, cn);
 
-    fd = TEMP_FAILURE_RETRY(open(fn, O_WRONLY | O_CREAT | O_TRUNC | O_SYNC, STASH_FILE_MODE));
+    fd = TEMP_FAILURE_RETRY(open(fn, O_WRONLY | O_CREAT | O_TRUNC, STASH_FILE_MODE));
 
     if (fd == -1) {
         fprintf(stderr, "failed to create %s (errno %d)\n", fn, errno);
@@ -1703,6 +1698,10 @@ static Value* PerformBlockImageUpdate(const char* name, State* state, int argc, 
         }
 
         if (params.canwrite) {
+            if (fsync(params.fd) == -1) {
+                fprintf(stderr, "fsync failed: %s\n", strerror(errno));
+                goto pbiudone;
+            }
             fprintf(cmd_pipe, "set_progress %.4f\n", (double) params.written / total_blocks);
             fflush(cmd_pipe);
         }


### PR DESCRIPTION
Currently the fsync() inside write_all() may be called multiple times
when performing a command. Move that to the outer loop and call it
only after completing the command.

Also remove the O_SYNC flag when writing a stash.

Change-Id: I71e51d76051a2f7f504eef1aa585d2cb7a000d80
